### PR TITLE
Don't set mtu on debian/ubuntu

### DIFF
--- a/tasks/Debian.yml
+++ b/tasks/Debian.yml
@@ -54,7 +54,6 @@
           allow-hotplug {{ item.interface_device }}
           auto {{ item.interface_device }}
           iface {{ item.interface_device }} inet dhcp
-              mtu {{ interface_mtu }}
               {% if item.interface_default_gateway is defined and item.interface_default_gateway -%}
               gateway {{ item.interface_default_gateway }}
               up route add default gw {{ item.interface_default_gateway }}

--- a/templates/50-cloud-init.yaml.j2
+++ b/templates/50-cloud-init.yaml.j2
@@ -15,7 +15,6 @@ network:
         route-metric: 100
         use-dns: false
         use-routes: false
-      mtu: {{ interface_mtu }}
       {% if interface.interface_default_gateway is defined and interface.interface_default_gateway %}
       routes:
         - to: 0.0.0.0/0


### PR DESCRIPTION
Setting MTU on Debian/Ubuntu interfaces, when using DHCP, is not necessary (the correct value is fetched from DHCP). Setting it explicitly leads to a generally different (wrong) value than the one used in the OpenStack network.